### PR TITLE
Use the period argument in tt log

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ Get a log of all activities with the `log` (or `l`) command:
 
     $ tt log
 
+Get a log of all activities started within a time period:
+
+    $ tt log 2023-11-13 2023-11-15T13:00:00
+
+Accepts datetimes in ISO8601 format. End datetime not required.
 ### csv
 
 Get a list of all your individual log entries in CSV format, so that they can be imported

--- a/tt-dev.py
+++ b/tt-dev.py
@@ -69,7 +69,10 @@ def parse_args(argv=sys.argv):
 
     elif head in ['log']:
         fn = log.action_log
-        args = {'period': tail[0] if tail else None}
+        if len(tail) > 2:
+            raise BadArguments(
+                'Please provide no more than 2 arguments to log (start and end datetime in ISO8601 format)')
+        args = {'period': tail}
 
     elif head in ['csv']:
         fn = csv.action_csv

--- a/tt/actions/read/log.py
+++ b/tt/actions/read/log.py
@@ -6,21 +6,19 @@ from tt.dateutils.dateutils import *
 from tt.colors.colors import *
 
 
-def action_log(period=None):
+def action_log(period=[]):
     data = get_data_store().load()
     work = data['work']
     log = defaultdict(lambda: {'delta': timedelta()})
     current = None
-    if period is not None:
-        period = [datetime.fromisoformat(dt) for dt in period]
+    period = [datetime.fromisoformat(dt) for dt in period]
     for item in work:
         start_time = parse_isotime(item['start'])
 
-        if period is not None:
-            if start_time < period[0]:
-                continue
-            if len(period) > 1 and start_time > period[1]:
-                continue
+        if len(period) > 0 and start_time < period[0]:
+            continue
+        if len(period) > 1 and start_time > period[1]:
+            continue
 
         if 'end' in item:
             log[item['name']]['delta'] += (

--- a/tt/actions/read/log.py
+++ b/tt/actions/read/log.py
@@ -6,14 +6,21 @@ from tt.dateutils.dateutils import *
 from tt.colors.colors import *
 
 
-def action_log(period):
+def action_log(period=None):
     data = get_data_store().load()
     work = data['work']
     log = defaultdict(lambda: {'delta': timedelta()})
     current = None
-
+    if period is not None:
+        period = [datetime.fromisoformat(dt) for dt in period]
     for item in work:
         start_time = parse_isotime(item['start'])
+
+        if period is not None:
+            if start_time < period[0]:
+                continue
+            if len(period) > 1 and start_time > period[1]:
+                continue
 
         if 'end' in item:
             log[item['name']]['delta'] += (


### PR DESCRIPTION
`action_log` currently accepts a period argument, but does not use it at all.

This PR allows the user to provide a start time and (optional) end time to filter entries.