### PR TITLE
fix: group all activities together in generic report view

### DIFF
--- a/tt/actions/utils/reportingutils.py
+++ b/tt/actions/utils/reportingutils.py
@@ -5,7 +5,7 @@ def get_notes_from_workitem(item):
     notes = ''
     if 'notes' in item:
         for note in item['notes']:
-            notes += note + ' ; '
+            notes += note + '; '
     return notes
 
 


### PR DESCRIPTION
When generating a report without providing an activitiy, aggregate all notes belonging to the same activity into one entry.

It now looks like this:
`customer1: { Notes, notes notes; Some more notes }, cust2: { notes; some other notes } `